### PR TITLE
Split editor and player

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,18 @@
+[lib]
+crate-type = ["rlib"]
+
 [package]
 name = "cirquil"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "editor"
+path = "src/bin/editor.rs"
+
+[[bin]]
+name = "player"
+path = "src/bin/player.rs"
 
 [dependencies]
 quick-xml = { version = "0.31.0", features = ["serialize"] }

--- a/src/bin/editor.rs
+++ b/src/bin/editor.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Editor main()")
+}

--- a/src/bin/player.rs
+++ b/src/bin/player.rs
@@ -1,20 +1,11 @@
-// TODO: Remove this for release
-#![allow(dead_code)]
-
 use std::{env, fs};
 use std::process::exit;
 
 use egui::{Style, Visuals};
 
-use crate::gui::CirquilApp;
-use crate::logisim::converter::convert_circuit;
-use crate::logisim::parser::parse_logisim;
-
-
-mod core;
-mod gui;
-mod logisim;
-mod test_propagate;
+use cirquil::logisim::converter::convert_circuit;
+use cirquil::logisim::parser::parse_logisim;
+use cirquil::player::CirquilPlayerApp;
 
 fn main() -> Result<(), eframe::Error> {
     // let filename = Path::new("test_.circ".to_string());
@@ -26,12 +17,6 @@ fn main() -> Result<(), eframe::Error> {
             exit(1);
         }
     }
-    
-    // test_not();
-    // test_propagate();
-    // test_or();
-    //
-    // return Ok(());
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size([1000.0, 600.0]),
@@ -50,7 +35,7 @@ fn main() -> Result<(), eframe::Error> {
 
             let (circuit, canvas) = convert_circuit(parse_logisim(filename), 0);
             circuit.propagate_all();
-            Box::new(CirquilApp { circuit, canvas })
+            Box::new(CirquilPlayerApp { circuit, canvas })
         }),
     )
 }

--- a/src/bin/player.rs
+++ b/src/bin/player.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), eframe::Error> {
     };
 
     eframe::run_native(
-        "Cirquil",
+        "Cirquil Player",
         options,
         Box::new(|cc| {
             let style = Style {

--- a/src/bin/player.rs
+++ b/src/bin/player.rs
@@ -8,14 +8,13 @@ use cirquil::logisim::parser::parse_logisim;
 use cirquil::player::CirquilPlayerApp;
 
 fn main() -> Result<(), eframe::Error> {
-    // let filename = Path::new("test_.circ".to_string());
-    let filename = env::var("INPUT_FILE").unwrap_or(String::from("test.circ"));
-    match fs::metadata(&filename) {
-        Ok(_) => {}
-        Err(err) => {
-            println!("{}: {}", err, filename);
-            exit(1);
-        }
+    let args: Vec<String> = env::args().collect();
+
+    let filename = args.get(1).unwrap_or(&"test.circ".to_string()).clone();
+    
+    if let Err(err) = fs::metadata(&filename) {
+        println!("{}: {}", err, filename);
+        exit(1);
     }
 
     let options = eframe::NativeOptions {

--- a/src/core/simulation/circuit.rs
+++ b/src/core/simulation/circuit.rs
@@ -28,7 +28,7 @@ impl Circuit {
     pub fn tick(&self) {
         for clock_idx in self.clock_generators.iter() {
             let clock = self.get_component(*clock_idx);
-            
+
             if let ComponentModel::ClockGenerator(c) = &clock.component {
                 c.tick()
             }

--- a/src/core/simulation/components/tunnel.rs
+++ b/src/core/simulation/components/tunnel.rs
@@ -50,7 +50,7 @@ impl Tunnel {
     pub fn from_name_width(name: &str, bit_width: u8) -> Component {
         let properties = ComponentProperties::new(vec![
             ("bit_width".to_string(), Property::Integer(IntegerProperty::new(bit_width as u32))),
-            ("name".to_string(), Property::String(StringProperty::new(name.to_string())))
+            ("name".to_string(), Property::String(StringProperty::new(name.to_string()))),
         ]);
 
         Self::from_properties(properties)

--- a/src/gui/components/tunnel.rs
+++ b/src/gui/components/tunnel.rs
@@ -1,5 +1,6 @@
 use eframe::emath::{Pos2, Rect};
 use eframe::epaint::{Color32, Rounding, Shape, Stroke};
+
 use crate::core::simulation::components::tunnel::Tunnel;
 use crate::gui::component::{AsShapes, Bounds};
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,10 +1,6 @@
-pub use app::CirquilApp;
-
-mod app;
-mod grid;
-mod constants;
-mod components;
-mod location;
-
+pub mod grid;
+pub mod constants;
+pub mod components;
+pub mod location;
 pub mod component;
 pub mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+// TODO: Remove this for release
+#![allow(dead_code)]
+
+pub mod core;
+pub mod gui;
+pub mod logisim;
+pub mod editor;
+pub mod player;

--- a/src/logisim/converter/dfs.rs
+++ b/src/logisim/converter/dfs.rs
@@ -59,8 +59,8 @@ fn dfs_wires_internal(current: &LogisimLocation,
                       segments: &mut Vec<(Location, Location)>,
                       circuit_nodes: &mut Vec<Location>) {
     let wires = wires_map.remove(current).unwrap();
-    
-    match wires.len() { 
+
+    match wires.len() {
         2 => {
             let first = if *current == wires[0].to {
                 wires[0].from
@@ -83,25 +83,25 @@ fn dfs_wires_internal(current: &LogisimLocation,
         }
         _ => {}
     }
-    
+
     for i in wires.iter() {
         let next = if *current == i.to {
             i.from
         } else {
             i.to
         };
-        
+
         if wires_map.contains_key(&next) {
             segments.push((Location::new(i.from.x, i.from.y), Location::new(i.to.x, i.to.y)));
         }
     }
     for i in wires.iter() {
-        let next= if *current == i.to {
+        let next = if *current == i.to {
             i.from
         } else {
             i.to
         };
-        
+
         if wires_map.contains_key(&next) {
             dfs_wires_internal(&next, wires_map,
                                loc_to_tunnel,

--- a/src/logisim/converter/mod.rs
+++ b/src/logisim/converter/mod.rs
@@ -121,11 +121,11 @@ pub fn convert_circuit(parsed_project: LogisimProject, circuit_idx: usize) -> (C
     }
 
     (Circuit { components, wires, clock_generators },
-            CanvasCircuit {
-                components: canvas_components,
-                wires: canvas_wires,
-                circuit: circuit_idx,
-                appearance: (),
-                pins: (),
-            })
+     CanvasCircuit {
+         components: canvas_components,
+         wires: canvas_wires,
+         circuit: circuit_idx,
+         appearance: (),
+         pins: (),
+     })
 }

--- a/src/player/app.rs
+++ b/src/player/app.rs
@@ -11,12 +11,12 @@ use crate::gui::value::get_value_color;
 
 const GRID_SQUARE: Vec2 = Vec2::new(GRID_STEP, GRID_STEP);
 
-pub struct CirquilApp {
+pub struct CirquilPlayerApp {
     pub circuit: Circuit,
     pub canvas: CanvasCircuit,
 }
 
-impl eframe::App for CirquilApp {
+impl eframe::App for CirquilPlayerApp {
     fn update(&mut self, ctx: &Context, _frame: &mut Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             StripBuilder::new(ui)

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,0 +1,3 @@
+pub use app::CirquilPlayerApp;
+
+pub mod app;

--- a/src/test_propagate.rs
+++ b/src/test_propagate.rs
@@ -67,15 +67,15 @@ pub fn test_or() {
     or.set_pin_value(0, Value::new(8, 0));
     or.set_pin_value(1, Value::new(2, 0));
 
-    let wire = Wire { value: Cell::new(Default::default()), connected_components: vec![(0, 0), (1, 0) ] };
+    let wire = Wire { value: Cell::new(Default::default()), connected_components: vec![(0, 0), (1, 0)] };
 
     clock.set_pin_wire(0, Some(0));
     or.set_pin_wire(0, Some(0));
 
     let circuit = Circuit {
-        components: vec![ or, clock ],
-        wires: vec![ wire ],
-        clock_generators: vec![ 1 ],
+        components: vec![or, clock],
+        wires: vec![wire],
+        clock_generators: vec![1],
     };
 
     println!("{:?} {:?}", circuit.components, circuit.wires);
@@ -105,15 +105,15 @@ pub fn test_not() {
     let clock = ClockGenerator::create();
     let not = NotGate::from_bit_width(2);
 
-    let wire = Wire { value: Cell::new(Default::default()), connected_components: vec![(0, 0), (1, 0) ] };
+    let wire = Wire { value: Cell::new(Default::default()), connected_components: vec![(0, 0), (1, 0)] };
 
     clock.set_pin_wire(0, Some(0));
     not.set_pin_wire(0, Some(0));
 
     let circuit = Circuit {
-        components: vec![ clock, not ],
-        wires: vec![ wire ],
-        clock_generators: vec![ 0 ],
+        components: vec![clock, not],
+        wires: vec![wire],
+        clock_generators: vec![0],
     };
 
     println!("{:?} {:?}", circuit.components, circuit.wires);

--- a/tests/test_propagate.rs
+++ b/tests/test_propagate.rs
@@ -1,14 +1,15 @@
 use std::cell::Cell;
 use std::time::Instant;
 
-use crate::core::simulation::circuit::Circuit;
-use crate::core::simulation::components::clock_generator::ClockGenerator;
-use crate::core::simulation::components::logic::and_gate::AndGate;
-use crate::core::simulation::components::logic::not_gate::NotGate;
-use crate::core::simulation::components::logic::or_gate::OrGate;
-use crate::core::simulation::value::Value;
-use crate::core::simulation::wire::Wire;
+use cirquil::core::simulation::circuit::Circuit;
+use cirquil::core::simulation::components::clock_generator::ClockGenerator;
+use cirquil::core::simulation::components::logic::and_gate::AndGate;
+use cirquil::core::simulation::components::logic::not_gate::NotGate;
+use cirquil::core::simulation::components::logic::or_gate::OrGate;
+use cirquil::core::simulation::value::Value;
+use cirquil::core::simulation::wire::Wire;
 
+#[test]
 pub fn test_propagate() {
     let clock = ClockGenerator::create();
 
@@ -59,6 +60,7 @@ pub fn test_propagate() {
     println!("{:?} {:?} MHz", start.elapsed(), 1f64 / (start.elapsed().as_micros() as f64 / 1_000_000f64));
 }
 
+#[test]
 pub fn test_or() {
     let clock = ClockGenerator::create();
 
@@ -101,6 +103,7 @@ pub fn test_or() {
     println!("{:?} {:?} MHz", start.elapsed(), 1f64 / (start.elapsed().as_micros() as f64 / 1_000_000f64));
 }
 
+#[test]
 pub fn test_not() {
     let clock = ClockGenerator::create();
     let not = NotGate::from_bit_width(2);


### PR DESCRIPTION
Restructure project so it can support editor and player.

- Change crate type to `lib`
- Create entry points and modules for editor and player
- Move current player code to distinct module
- Move `test_propagate.rs` to tests folder
- Change player to take circuit file from arguments